### PR TITLE
feat: add theme provider and app providers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,1 @@
-function App() {
-  return <h1>hello</h1>
-}
-
-export default App
+export const App = () => <div>hello</div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App'
+import { AppProviders } from 'shared'
+import { App } from './App'
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
-    <App />
+    <AppProviders>
+      <App />
+    </AppProviders>
   </React.StrictMode>
 )

--- a/src/shared/components/AppProviders/AppProviders.component.tsx
+++ b/src/shared/components/AppProviders/AppProviders.component.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { ThemeProvider } from 'ui-kit'
+
+interface AppProvidersProps {
+  children: React.ReactNode
+}
+
+export const AppProviders = ({ children }: AppProvidersProps) => {
+  return <ThemeProvider>{children}</ThemeProvider>
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,1 @@
+export { AppProviders } from './components/AppProviders/AppProviders.component'

--- a/src/ui-kit/Theme/components/GlobalStyles/GlobalStyles.styles.ts
+++ b/src/ui-kit/Theme/components/GlobalStyles/GlobalStyles.styles.ts
@@ -1,0 +1,24 @@
+import { createGlobalStyle } from 'styled-components'
+
+export const GlobalStyles = createGlobalStyle`
+    * { 
+        box-sizing: border-box;
+        padding: 0;
+        margin: 0;
+    }
+    html {
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 16px;
+        height:100%;
+        min-height: 100vh;
+    }
+    
+    body {
+        height:100%;
+        min-height: 100vh;
+    }
+    a {
+        color: inherit;
+        text-decoration: none;
+    }
+`

--- a/src/ui-kit/Theme/components/ResetStyles/ResetStyles.styles.ts
+++ b/src/ui-kit/Theme/components/ResetStyles/ResetStyles.styles.ts
@@ -1,0 +1,54 @@
+import { createGlobalStyle } from 'styled-components'
+
+export const ResetStyles = createGlobalStyle`
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+margin: 0;
+padding: 0;
+border: 0;
+font-size: 100%;
+font: inherit;
+vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+display: block;
+}
+body {
+line-height: 1;
+}
+html{
+font-size: 16px;
+}
+ol, ul {
+list-style: none;
+}
+blockquote, q {
+quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+content: '';
+content: none;
+}
+table {
+border-collapse: collapse;
+border-spacing: 0;
+}
+`

--- a/src/ui-kit/Theme/components/ThemeProvider/ThemeProvider.component.tsx
+++ b/src/ui-kit/Theme/components/ThemeProvider/ThemeProvider.component.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { ThemeProvider as ThemeProviderStyled } from 'styled-components'
+import { theme } from '../../theme.consts'
+import { GlobalStyles } from '../GlobalStyles/GlobalStyles.styles'
+import { ResetStyles } from '../ResetStyles/ResetStyles.styles'
+
+interface ThemeProps {
+  children: React.ReactNode
+}
+
+export const ThemeProvider = ({ children }: ThemeProps) => {
+  return (
+    <>
+      <ResetStyles />
+      <GlobalStyles />
+      <ThemeProviderStyled theme={theme}>{children}</ThemeProviderStyled>
+    </>
+  )
+}

--- a/src/ui-kit/Theme/styled.d.ts
+++ b/src/ui-kit/Theme/styled.d.ts
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+import 'styled-components'
+
+interface CustomTheme {
+  color: {
+    white: '#FFFFFF'
+    black: '#000000'
+    primary: '#6922D3'
+    backgroundPrimary: '#F0E9FA'
+    backgroundSecondary: '#EBECF0'
+    textPrimary: '#363D65'
+    textSecondary: '#5E6484'
+  }
+  fontFamily: {
+    primary: 'Helvetica'
+  }
+  media: {
+    minTablet: '@media(min-width: 767px)'
+    minDesktop: '@media(min-width: 1200px)'
+  }
+  transition: '0.3s cubic-bezier(0.17, 0.67, 0.31, 1.04)'
+}
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends CustomTheme {}
+}

--- a/src/ui-kit/Theme/theme.consts.ts
+++ b/src/ui-kit/Theme/theme.consts.ts
@@ -1,0 +1,21 @@
+import { DefaultTheme } from 'styled-components'
+
+export const theme: DefaultTheme = {
+  color: {
+    white: '#FFFFFF',
+    black: '#000000',
+    primary: '#6922D3',
+    backgroundPrimary: '#F0E9FA',
+    backgroundSecondary: '#EBECF0',
+    textPrimary: '#363D65',
+    textSecondary: '#5E6484',
+  },
+  fontFamily: {
+    primary: 'Helvetica',
+  },
+  media: {
+    minTablet: '@media(min-width: 767px)',
+    minDesktop: '@media(min-width: 1200px)',
+  },
+  transition: '0.3s cubic-bezier(0.17, 0.67, 0.31, 1.04)',
+}

--- a/src/ui-kit/index.ts
+++ b/src/ui-kit/index.ts
@@ -1,0 +1,1 @@
+export { ThemeProvider } from './Theme/components/ThemeProvider/ThemeProvider.component'


### PR DESCRIPTION
In this pull request:
- create theme provider
- create ui-kit library
- create app providers component 

Screenshots: 

No visual changes 